### PR TITLE
Add optionally selectable groups for customer subscriptions

### DIFF
--- a/core/components/commerce_mailchimp/lexicon/en/default.inc.php
+++ b/core/components/commerce_mailchimp/lexicon/en/default.inc.php
@@ -10,6 +10,9 @@ $_lang['commerce_mailchimp.list'] = 'MailChimp List';
 $_lang['commerce_mailchimp.list.description'] = 'Select the MailChimp list you would like to subscribe customers to.';
 $_lang['commerce_mailchimp.list.select'] = 'Select a MailChimp list...';
 
+$_lang['commerce_mailchimp.groups'] = 'MailChimp Groups';
+$_lang['commerce_mailchimp.groups.description'] = 'Optional: Select the group you would like to automatically subscribe customers to.';
+
 $_lang['commerce_mailchimp.address_type'] = 'Address Type';
 $_lang['commerce_mailchimp.address_type.description'] = 'Should billing addresses or shipping addresses be submitted to Mailchimp?';
 $_lang['commerce_mailchimp.address_type.select'] = 'Shipping address or billing address?';

--- a/core/components/commerce_mailchimp/src/Admin/Widgets/Form/MailChimpCheckboxGroupField.php
+++ b/core/components/commerce_mailchimp/src/Admin/Widgets/Form/MailChimpCheckboxGroupField.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace modmore\Commerce_MailChimp\Admin\Widgets\Form;
+
+use modmore\Commerce\Admin\Widgets\Form\TextField;
+
+class MailChimpCheckboxGroupField extends TextField
+{
+    public array $data;
+
+    function __construct(\Commerce $commerce, array $options = [])
+    {
+        if (array_key_exists('data', $options)) {
+            $this->data = $options['data'];
+        }
+
+        parent::__construct($commerce, $options);
+    }
+
+    public function getHTML(): string
+    {
+        return $this->commerce->view()->render('mailchimp/fields/admin/mailchimpcheckboxgroup.twig', [
+            'field' => $this,
+            'data' => $this->data,
+        ]);
+    }
+
+    public function setValue($value): MailChimpCheckboxGroupField
+    {
+        return $this;
+    }
+}

--- a/core/components/commerce_mailchimp/src/MailchimpClient.php
+++ b/core/components/commerce_mailchimp/src/MailchimpClient.php
@@ -77,8 +77,11 @@ class MailchimpClient
         $customerData['merge_fields']['FNAME'] = $firstName;
         $customerData['merge_fields']['LNAME'] = $lastName;
 
+        // If groups are set, assign them to the subscription data
         if (!empty($groups)) {
-            // @todo alter subscribe request to assign groups
+            foreach ($groups as $id => $value) {
+                $customerData['interests'][$id] = true;
+            }
         }
 
         $customerDataJSON = json_encode($customerData);

--- a/core/components/commerce_mailchimp/src/MailchimpClient.php
+++ b/core/components/commerce_mailchimp/src/MailchimpClient.php
@@ -62,7 +62,7 @@ class MailchimpClient
     }
 
 
-    public function subscribeCustomer(string $listId, \comOrderAddress $address, $doubleOptIn)
+    public function subscribeCustomer(string $listId, \comOrderAddress $address, $doubleOptIn, array $groups = [])
     {
         // Try to get the right names
         $firstName = $address->get('firstname');
@@ -76,6 +76,10 @@ class MailchimpClient
         $customerData['status'] = $doubleOptIn ? 'pending' : 'subscribed';
         $customerData['merge_fields']['FNAME'] = $firstName;
         $customerData['merge_fields']['LNAME'] = $lastName;
+
+        if (!empty($groups)) {
+            // @todo alter subscribe request to assign groups
+        }
 
         $customerDataJSON = json_encode($customerData);
 
@@ -99,27 +103,40 @@ class MailchimpClient
     }
 
     /**
-     * Function: getLists
-     *
-     * Returns an array of lists in assigned MailChimp account.
-     * Array is formatted for the standard Commerce select field.
-     * @return array|bool
+     * @param string $uri
+     * @return array|null
      */
-    public function getLists()
+    protected function getRequest(string $uri): ?array
     {
         $client = new Client();
         try {
-            $res = $client->request('GET', $this->apiUrl . 'lists', [
+            $res = $client->request('GET', $this->apiUrl . $uri, [
                 'auth' => ['apikey', $this->apiKey],
             ]);
         } catch (GuzzleException $guzzleException) {
             $this->commerce->adapter->log(MODX_LOG_LEVEL_ERROR, $guzzleException->getMessage());
-            return false;
+            return null;
         }
 
         $responseArray = json_decode($res->getBody(), true);
         if (!is_array($responseArray)) {
-            return false;
+            return null;
+        }
+
+        return $responseArray;
+    }
+
+    /**
+     * Function: getLists
+     *
+     * Returns an array of lists in assigned MailChimp account.
+     * Array is formatted for the standard Commerce select field.
+     * @return array
+     */
+    public function getLists(): ?array
+    {
+        if (!$responseArray = $this->getRequest('lists')) {
+            return null;
         }
 
         $lists = [];
@@ -133,6 +150,48 @@ class MailchimpClient
         return $lists;
     }
 
+    /**
+     * @param string $listId
+     * @return array|null
+     */
+    public function getGroupCategories(string $listId): ?array
+    {
+        if (!$responseArray = $this->getRequest("lists/{$listId}/interest-categories")) {
+            return null;
+        }
+
+        $categories = [];
+        foreach ($responseArray['categories'] as $category) {
+            $categories[] = [
+                'id' => $category['id'],
+                'label' => $category['title']
+            ];
+        }
+
+        return $categories;
+    }
+
+    /**
+     * @param string $listId
+     * @param string $categoryId
+     * @return array|null
+     */
+    public function getGroups(string $listId, string $categoryId): ?array
+    {
+        if (!$responseArray = $this->getRequest("lists/{$listId}/interest-categories/{$categoryId}/interests")) {
+            return null;
+        }
+
+        $groups = [];
+        foreach ($responseArray['interests'] as $group) {
+            $groups[] = [
+                'id' => $group['id'],
+                'label' => $group['name']
+            ];
+        }
+
+        return $groups;
+    }
 
     /**
      * Function: checkSubscription

--- a/core/components/commerce_mailchimp/src/Modules/Mailchimp.php
+++ b/core/components/commerce_mailchimp/src/Modules/Mailchimp.php
@@ -218,7 +218,7 @@ class Mailchimp extends BaseModule
                 $this->getConfig('listid'),
                 $address,
                 $this->getConfig('doubleoptin'),
-                $this->getConfig('mailchimp_group'),
+                $this->getConfig('mailchimp_groups'),
             );
 
             // Add order field for the new subscriber
@@ -281,7 +281,7 @@ class Mailchimp extends BaseModule
 
             // Group checkbox field
             $listId = $module->getProperty('listid', '');
-            $groupValues = $module->getProperty('mailchimp_group');
+            $groupValues = $module->getProperty('mailchimp_groups');
             if ($categories = $client->getGroupCategories($listId)) {
                 $data = [];
                 foreach ($categories as $category) {
@@ -294,16 +294,16 @@ class Mailchimp extends BaseModule
                         $row['groups'][] = [
                             'id' => $group['id'],
                             'label' => $group['label'],
-                            'value' => array_key_exists($group['id'], $groupValues) ? '1' : '',
+                            'value' => !empty($groupValues) && array_key_exists($group['id'], $groupValues) ? '1' : '',
                         ];
                     }
                     $data[] = $row;
                 }
                 $fields[] = new MailChimpCheckboxGroupField($this->commerce, [
-                    'name' => 'properties[mailchimp_group]',
+                    'name' => 'properties[mailchimp_groups]',
                     'label' => $this->adapter->lexicon('commerce_mailchimp.groups'),
                     'description' => $this->adapter->lexicon('commerce_mailchimp.groups.description'),
-                    'value' => $module->getProperty('mailchimp_group', ''),
+                    'value' => $module->getProperty('mailchimp_groups', ''),
                     'data' => $data,
                 ]);
             }

--- a/core/components/commerce_mailchimp/src/Modules/Mailchimp.php
+++ b/core/components/commerce_mailchimp/src/Modules/Mailchimp.php
@@ -261,7 +261,11 @@ class Mailchimp extends BaseModule
 
         // Check if list select box changed. Reload
         // @todo: find an alternative to checking $_REQUEST
-        if (isset($_REQUEST['properties']) && isset($_REQUEST['properties']['listid'])) {
+        if (
+            isset($_REQUEST['properties'])
+            && isset($_REQUEST['properties']['listid'])
+            && !isset($_REQUEST['_handleSubmit'])
+        ) {
             $this->commerce->modx->cacheManager->refresh(['commerce_mailchimp' => []]);
             $reload = true;
         }

--- a/core/components/commerce_mailchimp/templates/mailchimp/fields/admin/mailchimpcheckboxgroup.twig
+++ b/core/components/commerce_mailchimp/templates/mailchimp/fields/admin/mailchimpcheckboxgroup.twig
@@ -1,0 +1,17 @@
+<div class="horizontal field c-field-checkbox-group {{ field.inputClass }}">
+    <label>{{ field.label }}</label>
+    {% for category in field.data %}
+        <div class="ui relaxed list">
+            <label><strong>{{ category.label }}</strong></label>
+            {% for group in category.groups %}
+                <div class="item">
+                    <div class="ui child checkbox">
+                        <input id="mailchimp-group-{{ group.id }}" type="checkbox" name="properties[mailchimp_group][{{ group.id }}]" value="1" {% if group.value %}checked="checked"{% endif %}>
+                        <label for="mailchimp-group-{{ group.id }}">{{ group.label }}</label>
+                    </div>
+                </div>
+            {% endfor %}
+        </div>
+    {% endfor %}
+    {% if field.description %}<p class="help">{{ field.description }}</p>{% endif %}
+</div>

--- a/core/components/commerce_mailchimp/templates/mailchimp/fields/admin/mailchimpcheckboxgroup.twig
+++ b/core/components/commerce_mailchimp/templates/mailchimp/fields/admin/mailchimpcheckboxgroup.twig
@@ -6,7 +6,7 @@
             {% for group in category.groups %}
                 <div class="item">
                     <div class="ui child checkbox">
-                        <input id="mailchimp-group-{{ group.id }}" type="checkbox" name="properties[mailchimp_group][{{ group.id }}]" value="1" {% if group.value %}checked="checked"{% endif %}>
+                        <input id="mailchimp-group-{{ group.id }}" type="checkbox" name="properties[mailchimp_groups][{{ group.id }}]" value="1" {% if group.value %}checked="checked"{% endif %}>
                         <label for="mailchimp-group-{{ group.id }}">{{ group.label }}</label>
                     </div>
                 </div>


### PR DESCRIPTION
Todo: alter subscription request to assign to groups

This PR adds a custom checkbox group field to the module config window. 
Groups and categories and loaded via the API and displayed in a column for the admin to configure.